### PR TITLE
Fix gitignore models dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,10 +133,5 @@ dmypy.json
 *.DS_Store
 # config/
 output/
-*models/00001
-*models/00002_DCGAN_MMG_MASS_ROI/
-*models/00003
-*models/00004_PIX2PIX_MASKTOMASS_BREAST_MG_SYNTHESIS/
-*models/00005
-*models/00006
-
+models/*/**
+!models/00007_BEZIERCURVE_TUMOUR_MASK/**


### PR DESCRIPTION
Added generic definition of models directory to ignore in git and also a special case of 00007_BEZIERCURVE_TUMOUR_MASK to be included (as it is part of the repo).