### PR TITLE
Init: Short model_ids e.g. model_id=5 or 05 or 00005

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ Create mammography calcification images using DCGAN model
 from medigan import Generators
 generators = Generators()
 
-# generate 6 samples using one of the medigan models
-generators.generate(model_id="00001_DCGAN_MMG_CALC_ROI", num_samples=6)
+# generate 6 samples with model 1 (00001_DCGAN_MMG_CALC_ROI)
+generators.generate(model_id=1, num_samples=6)
 ```
 ![sample](docs/source/_static/samples/dcgan/gan_sample_1.png)
 ![sample](docs/source/_static/samples/dcgan/gan_sample_2.png)
@@ -91,8 +91,8 @@ Create mammograms translated from Low-to-High Breast Density using CYCLEGAN mode
 ```python
 from medigan import Generators
 generators = Generators()
-
-generators.generate(model_id="00003_CYCLEGAN_MMG_DENSITY_FULL", num_samples=1)
+# model 3 is "00003_CYCLEGAN_MMG_DENSITY_FULL"
+generators.generate(model_id=3, num_samples=1)
 ```
 ![sample](docs/source/_static/samples/cyclegan/sample_image_5_low.png)
 &rarr;
@@ -119,7 +119,8 @@ We can directly receive a [torch.utils.data.DataLoader](https://pytorch.org/docs
 ```python
 from medigan import Generators
 generators = Generators()
-dataloader = generators.get_as_torch_dataloader(model_id="00004_PIX2PIX_MASKTOMASS_BREAST_MG_SYNTHESIS", num_samples=3)
+# model 4 is "00004_PIX2PIX_MASKTOMASS_BREAST_MG_SYNTHESIS"
+dataloader = generators.get_as_torch_dataloader(model_id=4, num_samples=3)
 ```
 
 Visualize the contents of the dataloader.
@@ -146,7 +147,8 @@ With our interface, it is possible to generate sample by manually setting the co
 from medigan import Generators
 
 generators = Generators()
-generators.visualize("00010_FASTGAN_POLYP_PATCHES_W_MASKS")
+# model 10 is "00010_FASTGAN_POLYP_PATCHES_W_MASKS"
+generators.visualize(10)
 ```
 
 ![sample](docs/source/_static/interface.png)

--- a/docs/source/code_examples.rst
+++ b/docs/source/code_examples.rst
@@ -31,14 +31,16 @@ Get the model's generate method and run it to generate 3 samples
 
 .. code-block:: Python
 
-    gen_function = generators.get_generate_function(model_id="00001_DCGAN_MMG_CALC_ROI", num_samples=3)
+    # model 1 is "00001_DCGAN_MMG_CALC_ROI"
+    gen_function = generators.get_generate_function(model_id=1, num_samples=3)
     gen_function()
 
 Get the model's synthetic data as torch dataloader with 3 samples
 
 .. code-block:: Python
 
-    dataloader = generators.get_as_torch_dataloader(model_id="00004_PIX2PIX_MASKTOMASS_BREAST_MG_SYNTHESIS", num_samples=3)
+    # model 4 is "00004_PIX2PIX_MASKTOMASS_BREAST_MG_SYNTHESIS"
+    dataloader = generators.get_as_torch_dataloader(model_id=4, num_samples=3)
 
 
 Visualize Generative Model
@@ -48,7 +50,8 @@ Displays an interactive visual interface for exploration of applicable models.
 
 .. code-block:: Python
 
-    generators.visualize("00010_FASTGAN_POLYP_PATCHES_W_MASKS")
+    # model 10 is "00010_FASTGAN_POLYP_PATCHES_W_MASKS"
+    generators.visualize(10)
 
 .. figure:: _static/interface.png
    :alt: Visualization example for model 00010

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,9 @@ Let's install `medigan` and generate a few synthetic images.
 .. code-block:: Python
 
     from medigan import Generators
-    Generators().generate(model_id="00001_DCGAN_MMG_CALC_ROI")
+
+    # model 1 is "00001_DCGAN_MMG_CALC_ROI"
+    Generators().generate(model_id=1)
 
 
 Overview

--- a/src/medigan/config_manager.py
+++ b/src/medigan/config_manager.py
@@ -311,6 +311,36 @@ class ConfigManager:
             return False
         return True
 
+
+    def match_model_id(self, provided_model_id: str) -> bool:
+        """Replacing a model_id acronym (e.g. 00005 or 5) with the unique `model_id` present in the model metadata
+
+        Parameters
+        ----------
+        provided_model_id: str
+            The user-provided model_id that might be shorter (e.g. "00005" or "5") than the real unique model id
+
+        Returns
+        -------
+        str
+            If matched, returning the unique `model_id` present in global model metadata.
+        """
+
+        # (1) quick check if model_id is in config. In this case no matching is needed.
+        # (2) if the model id's length is >5, it comprises info different from the numeric id (e.g., 00001) and could
+        # be ambiguous (e.g. PGGAN_CHEST).
+        p_id_length = len(str(provided_model_id))
+        if not self.is_model_in_config(model_id=str(provided_model_id)) and p_id_length <= 5 and p_id_length > 0:
+            for i in range(5-p_id_length):
+                # Adding zeros e.g., to allow matching and to avoid returning 01015 instead of 00015.
+                provided_model_id = "0" + str(provided_model_id)
+            for model_id in self.model_ids:
+                if model_id[0:5] == str(provided_model_id):
+                    logging.debug(
+                        f"model_id[0:5]={model_id[0:5]}, provided_model_id={provided_model_id}. Matched: {model_id}")
+                    return model_id
+        return provided_model_id
+
     def __str__(self):
         return json.dumps(self.config_dict)
 

--- a/src/medigan/config_manager.py
+++ b/src/medigan/config_manager.py
@@ -311,7 +311,6 @@ class ConfigManager:
             return False
         return True
 
-
     def match_model_id(self, provided_model_id: str) -> bool:
         """Replacing a model_id acronym (e.g. 00005 or 5) with the unique `model_id` present in the model metadata
 
@@ -330,14 +329,19 @@ class ConfigManager:
         # (2) if the model id's length is >5, it comprises info different from the numeric id (e.g., 00001) and could
         # be ambiguous (e.g. PGGAN_CHEST).
         p_id_length = len(str(provided_model_id))
-        if not self.is_model_in_config(model_id=str(provided_model_id)) and p_id_length <= 5 and p_id_length > 0:
-            for i in range(5-p_id_length):
+        if (
+            not self.is_model_in_config(model_id=str(provided_model_id))
+            and p_id_length <= 5
+            and p_id_length > 0
+        ):
+            for i in range(5 - p_id_length):
                 # Adding zeros e.g., to allow matching and to avoid returning 01015 instead of 00015.
                 provided_model_id = "0" + str(provided_model_id)
             for model_id in self.model_ids:
                 if model_id[0:5] == str(provided_model_id):
                     logging.debug(
-                        f"model_id[0:5]={model_id[0:5]}, provided_model_id={provided_model_id}. Matched: {model_id}")
+                        f"model_id[0:5]={model_id[0:5]}, provided_model_id={provided_model_id}. Matched: {model_id}"
+                    )
                     return model_id
         return provided_model_id
 

--- a/src/medigan/generators.py
+++ b/src/medigan/generators.py
@@ -771,6 +771,8 @@ class Generators:
             Returns images as list of numpy arrays if `save_images` is False. However, if `is_gen_function_returned` is True, it returns the internal generate function of the model.
         """
 
+        model_id = self.config_manager.match_model_id(provided_model_id=model_id)
+
         model_executor = self.get_model_executor(
             model_id=model_id, install_dependencies=install_dependencies
         )
@@ -1064,6 +1066,8 @@ class Generators:
         num_samples: int
             the number of samples that will be generated
         """
+
+        model_id = self.config_manager.match_model_id(provided_model_id=model_id)
 
         if is_local_model:
             model_contributor = self.get_model_contributor_by_id(model_id=model_id)
@@ -1412,6 +1416,9 @@ class Generators:
         auto_close: bool
             Flag for closing the user interface automatically after time. Used while testing.
         """
+
+        model_id = self.config_manager.match_model_id(provided_model_id=model_id)
+
         config = self.get_config_by_id(model_id)
         model_executor = self.get_model_executor(model_id)
 

--- a/tests/test_model_executor.py
+++ b/tests/test_model_executor.py
@@ -24,10 +24,11 @@ models_with_args = [
         {},
         100,
     ),  # 100 samples to test automatic batch-wise image generation in model_executor
-    ("00002_DCGAN_MMG_MASS_ROI", {}, 3),
-    ("00003_CYCLEGAN_MMG_DENSITY_FULL", {"translate_all_images": False}, 2),
+    ("00002", {}, 3), # "00002" instead of "00002_DCGAN_MMG_MASS_ROI" to test shortcut model_ids
+    ("03", {"translate_all_images": False}, 2),  # "03" instead of "00003_CYCLEGAN_MMG_DENSITY_FULL" to test shortcut model_ids
+
     (
-        "00004_PIX2PIX_MASKTOMASS_BREAST_MG_SYNTHESIS",
+        4, # 4 instead of "00004_PIX2PIX_MASKTOMASS_BREAST_MG_SYNTHESIS" to test shortcut model_ids
         {
             "shapes": ["oval"],
             "ssim_threshold": 0.18,

--- a/tests/test_model_executor.py
+++ b/tests/test_model_executor.py
@@ -24,11 +24,18 @@ models_with_args = [
         {},
         100,
     ),  # 100 samples to test automatic batch-wise image generation in model_executor
-    ("00002", {}, 3), # "00002" instead of "00002_DCGAN_MMG_MASS_ROI" to test shortcut model_ids
-    ("03", {"translate_all_images": False}, 2),  # "03" instead of "00003_CYCLEGAN_MMG_DENSITY_FULL" to test shortcut model_ids
-
     (
-        4, # 4 instead of "00004_PIX2PIX_MASKTOMASS_BREAST_MG_SYNTHESIS" to test shortcut model_ids
+        "00002",
+        {},
+        3,
+    ),  # "00002" instead of "00002_DCGAN_MMG_MASS_ROI" to test shortcut model_ids
+    (
+        "03",
+        {"translate_all_images": False},
+        2,
+    ),  # "03" instead of "00003_CYCLEGAN_MMG_DENSITY_FULL" to test shortcut model_ids
+    (
+        4,  # 4 instead of "00004_PIX2PIX_MASKTOMASS_BREAST_MG_SYNTHESIS" to test shortcut model_ids
         {
             "shapes": ["oval"],
             "ssim_threshold": 0.18,


### PR DESCRIPTION
 User can now specify shorter, more convenient, model ids. 

For example, model_id=5 or "05" or "00005" instead of "00005_DCGAN_MMG_MASS_ROI".